### PR TITLE
Modify the declaration of WordEdit functions

### DIFF
--- a/edit.h
+++ b/edit.h
@@ -4,8 +4,11 @@
 #include <string>
 #include <unordered_set>
 
-std::unordered_set<std::string> Word1Edit(const std::string &error);
-std::unordered_set<std::string> Word2Edit(const std::string &error);
+//std::unordered_set<std::string> Word1Edit(const std::string &error);
+//std::unordered_set<std::string> Word2Edit(const std::string &error);
+
+void Word1Edit(std::unordered_set<std::string> &uset1, const std::string &error);
+void Word2Edit(std::unordered_set<std::string> &uset2, const std::string &error);
 
 #endif // EDIT_H
 


### PR DESCRIPTION
Returning a unordered_set instance will cause a unnecessary copy, I would use a reference as a parameter.